### PR TITLE
Adding Gfish to companies

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,8 @@ companies:
   url: http://fab-it.dk/
 - name: Firmafon
   url: http://www.firmafon.dk
+- name: Gfish
+  url: http://gfish.com
 - name: GoMore
   url: http://www.gomore.dk
 - name: Greenline


### PR DESCRIPTION
Gfish is the actual company maintaining and developing the code for Downtown and Take Offer earlier added to the list
