### PR TITLE
Remove Twitter Timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,17 +82,4 @@ layout: default
       </div>
     </div>
   </section>
-
-  <hr>
-
-  <section id="timeline">
-    <h2>Member activity</h2>
-    <p>
-      <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/copenhagenrb/lists/copenhagenrb" data-widget-id="577131471271522304">
-        Tweets from https://twitter.com/copenhagenrb/lists/copenhagenrb
-      </a>
-    </p>
-
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-  </section>
 </div>


### PR DESCRIPTION
I saw Bannon in a photo when I scrolled 
a few pages
of tweets 
that were mostly media RTs
and zero Ruby content.

(I want a no-Bannon Copenhagen.rb experience.)

This PR removes the twitter widget.