### PR TITLE
Add Tonsser to list of companies using Ruby

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,6 +70,8 @@ companies:
   url: http://www.takeoffer.dk
 - name: The Fashion
   url: http://thefashion.dk
+- name: Tonsser
+  url: https://tonsser.com
 - name: Vivino
   url: http://www.vivino.com
 - name: Zendesk


### PR DESCRIPTION
[Tonsser][] should totally be on the list of companies using Ruby. Our backend API is all Rails and we also have a [few](https://github.com/tonsser/takes_macro) [open-source](https://github.com/tonsser/tonsser-hash-utils) [gems](https://github.com/tonsser/cmdline_arg_parser).

Great talks yesterday btw. See you at the next meet up 😄 

[Tonsser]: https://tonsser.com